### PR TITLE
Show/hide calendar in small screens

### DIFF
--- a/app/lang/es/exhibitions.yml
+++ b/app/lang/es/exhibitions.yml
@@ -8,6 +8,7 @@ frontend:
         title: Cine UNAM
         subtitle: Consulta programación
         exhibitions_in_the_day: ':number exhibiciones en este día'
+        show_calendar: Mostrar calendario
     auditorium:
         index:
             title: Ubicación Salas de cine
@@ -27,7 +28,7 @@ frontend:
     invitations:
         index:
             title: Invitaciones
-            old: 
+            old:
                 title: Invitaciones Anteriores
     exhibition:
         index:

--- a/app/views/exhibitions/frontend/exhibitions/partials/calendar.blade.php
+++ b/app/views/exhibitions/frontend/exhibitions/partials/calendar.blade.php
@@ -1,5 +1,5 @@
 <div class="calendar">
-    <div class="header-programming">
+    <div class="header-programming hidden-xs">
         <h2 class="text-center">@lang('exhibitions.frontend.calendar.title')</h2>
         <h5 class="text-center">@lang('exhibitions.frontend.calendar.subtitle')</h5>
     </div>

--- a/app/views/exhibitions/frontend/exhibitions/partials/searcher-form.blade.php
+++ b/app/views/exhibitions/frontend/exhibitions/partials/searcher-form.blade.php
@@ -1,0 +1,15 @@
+{{ Form::open(['route' => 'exhibitions.frontend.exhibitions.index', 'method' => 'GET']) }}
+<div class="input-group">
+    <label class="hidden" for="name">
+        @lang('exhibitions.frontend.exhibition.index.search')
+    </label>
+    <input type="text"
+           class="form-control"
+           id="films-searcher"
+           name="title"
+           placeholder="@lang('exhibitions.frontend.exhibition.index.search')">
+    <div class="input-group-addon">
+        <span class="glyphicon glyphicon-search"></span>
+    </div>
+</div>
+{{ Form::close() }}

--- a/app/views/exhibitions/frontend/exhibitions/partials/sidebar.blade.php
+++ b/app/views/exhibitions/frontend/exhibitions/partials/sidebar.blade.php
@@ -1,0 +1,29 @@
+@include('exhibitions.frontend.exhibitions.partials.searcher-form')
+
+<div class="flm-section programming">
+    <div class="margin-top link-group">
+        @include('exhibitions.frontend.exhibitions.partials.programming')
+    </div>
+</div>
+
+@include('exhibitions.frontend.exhibitions.partials.billboard-subscription-form')
+
+<br><br>
+
+<div class="hidde-when-small hidden-xs">
+    <div class="fb-page"
+         data-href="https://www.facebook.com/Comunidad.Cines.UNAM/?fref=ts"
+         data-tabs="timeline"
+         data-small-header="true"
+         data-adapt-container-width="true"
+         data-hide-cover="false"
+         data-show-facepile="true">
+        <div class="fb-xfbml-parse-ignore">
+            <blockquote cite="https://www.facebook.com/Comunidad.Cines.UNAM/?fref=ts">
+                <a href="https://www.facebook.com/Comunidad.Cines.UNAM/?fref=ts">
+                    @lang('exhibitions.frontend.exhibition.show.unam_cinemas_community')
+                </a>
+            </blockquote>
+        </div>
+    </div>
+</div>

--- a/app/views/exhibitions/layouts/frontend.blade.php
+++ b/app/views/exhibitions/layouts/frontend.blade.php
@@ -1,66 +1,18 @@
 @extends('layouts.default')
 
 @section('sidebar')
-
-
-    {{ Form::open(['route' => 'exhibitions.frontend.exhibitions.index', 'method' => 'GET']) }}
-        <div class="input-group">
-            <div class="input-group-addon">
-                <span class="glyphicon glyphicon-search"></span>
-            </div>
-            <label class="hidden" for="name">
-                @lang('exhibitions.frontend.exhibition.index.search')
-            </label>
-            <input type="text"
-                   class="form-control"
-                   id="films-searcher"
-                   name="title"
-                   placeholder="@lang('exhibitions.frontend.exhibition.index.search')">
-            <div class="input-group-addon">&gt;</div>
-        </div>
-    {{ Form::close() }}
-
-    <div class="flm-section programming">
-        <div class="margin-top link-group">
-            @include('exhibitions.frontend.exhibitions.partials.programming')
-        </div>
+    <div class="hidden-xs">
+        @include('exhibitions.frontend.exhibitions.partials.sidebar')
     </div>
-    @include('exhibitions.frontend.exhibitions.partials.billboard-subscription-form')
 
-    <br><br>
-
-    <div class="hidde-when-small">
-        <div class="fb-page" 
-            data-href="https://www.facebook.com/Comunidad.Cines.UNAM/?fref=ts" 
-            data-tabs="timeline" 
-            data-small-header="true" 
-            data-adapt-container-width="true" 
-            data-hide-cover="false" 
-            data-show-facepile="true">
-            <div class="fb-xfbml-parse-ignore">
-                <blockquote cite="https://www.facebook.com/Comunidad.Cines.UNAM/?fref=ts">
-                    <a href="https://www.facebook.com/Comunidad.Cines.UNAM/?fref=ts">
-                        @lang('exhibitions.frontend.exhibition.show.unam_cinemas_community')
-                    </a>
-                </blockquote>
-            </div>
+    <div class="visible-xs">
+        @include('exhibitions.frontend.exhibitions.partials.searcher-form')
+        <div id="exhibitions-calendar-button" class="btn btn-default center-block">
+            <span class="glyphicon glyphicon-calendar"></span>
+            @lang('exhibitions.frontend.calendar.show_calendar')
         </div>
-    </div>
-    <div class="hidde-when-normal">
-        <div class="fb-page" 
-            data-href="https://www.facebook.com/Comunidad.Cines.UNAM/" data-tabs="timeline" 
-            data-height="190" 
-            data-small-header="true" 
-            data-adapt-container-width="true" 
-            data-hide-cover="false" 
-            data-show-facepile="true">
-            <div class="fb-xfbml-parse-ignore">
-                <blockquote cite="https://www.facebook.com/Comunidad.Cines.UNAM/">
-                    <a href="https://www.facebook.com/Comunidad.Cines.UNAM/">
-                        Comunidad  Cines UNAM
-                    </a>
-                </blockquote>
-            </div>
+        <div id="exhibitions-calendar" style="display: none">
+            @include('exhibitions.frontend.exhibitions.partials.calendar')
         </div>
     </div>
 @stop

--- a/htdocs/assets/js/filmoteca.min.js
+++ b/htdocs/assets/js/filmoteca.min.js
@@ -87,7 +87,8 @@ $(document).ready(function () {
 $(document).ready(function () {
     'use strict';
 
-    if (typeof filmotecaConfig.filmotecaMedal === 'undefined') {
+    if (typeof filmotecaConfig === 'undefined' ||
+        typeof filmotecaConfig.filmotecaMedal === 'undefined') {
         return;
     }
 
@@ -191,4 +192,11 @@ $(document).ready(function () {
             )
             .appendTo(ul);
     };
+});
+
+
+$(document).ready(function () {
+    $('#exhibitions-calendar-button').click(function () {
+        $('#exhibitions-calendar').slideToggle();
+    });
 });


### PR DESCRIPTION
Removí el sidebar, aquel donde aparece el calendario y el widget de facebook, de todas las pantallas asociadas con las exhibiciones, pero únicamente en pantallas pequeñas y así mejorar la experiencia del usuario en pantallas pequeñas.